### PR TITLE
add binary wheel distribution to releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ deploy:
   password: "${PYPI_PASSWORD}"
   on:
     tags: true
+  distributions: "sdist bdist_wheel"
 
 notifications:
   email:


### PR DESCRIPTION
We should be distributing binary versions for ease of use. This adds it to travis when automatically distributing tags via pypi.