### PR TITLE
use external urlzsource

### DIFF
--- a/opentargets_validator/cli.py
+++ b/opentargets_validator/cli.py
@@ -5,8 +5,9 @@ import logging
 import logging.config
 import sys
 
-from opentargets_validator.helpers import file_or_resource, URLZSource
+from opentargets_validator.helpers import file_or_resource
 from opentargets_validator.validator import validate
+from opentargets_urlzsource import URLZSource
 
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ codecov
 
 #for python2 and 3 compatibility
 future
+
+opentargets-urlzsource

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(name=__pkgname__,
     keywords=['opentargets', 'bioinformatics', 'python2'],
     platforms=['any'],
     #make sure this matches requirements.txt
-    install_requires=['requests','jsonschema==3.0.0a3', 'rfc3987', 'future'],
+    install_requires=['requests','jsonschema==3.0.0a3', 'rfc3987', 'future', 'opentargets-urlzsource'],
     dependency_links=[],
     include_package_data=True,
     entry_points={'console_scripts': ['opentargets_validator=opentargets_validator.cli:main'],},

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -1,8 +1,8 @@
 import unittest
 import os
-from opentargets_validator.helpers import file_or_resource, URLZSource
+from opentargets_validator.helpers import file_or_resource
 from opentargets_validator.validator import validate
-
+from opentargets_urlzsource import URLZSource
 
 class MinimalTests(unittest.TestCase):
 


### PR DESCRIPTION
Update to use the external urlzsource epednency rather than an internal fork. closes opentargets/platform#534