### PR TITLE
line_counter=0 if file cannot be parsed

### DIFF
--- a/opentargets_validator/validator.py
+++ b/opentargets_validator/validator.py
@@ -22,7 +22,7 @@ def validator_mapped(data, validator, logger):
         parsed_line = json.loads(line)
     except Exception as e:
         logger.error('failed parsing line %i: %s', line_counter, e)
-        return line_counter, None, None
+        return 0, None, None
 
     validation_errors = [(".".join(error.absolute_path), error.message) for error in validator.iter_errors(parsed_line)]
 


### PR DESCRIPTION
This will avoid cryptic error message when there are issue with input file:

```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.7/bin/opentargets_validator", line 11, in <module>
    sys.exit(main())
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/opentargets_validator/cli.py", line 60, in main
    valid = validate(fh, args.schema, args.hash)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/opentargets_validator/validator.py", line 76, in validate
    if line_counter == 0:
UnboundLocalError: local variable 'line_counter' referenced before assignment
```

Insted, it will show the expected error message.