### PR TITLE
Update jsonschema to the latest stable version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 requests
 #pin to a version that starts to support schema 7
-jsonschema==3.2.0
+jsonschema>=3.0.2
 
 #require to validate uris
 rfc3987

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 requests
 #pin to a version that starts to support schema 7
-jsonschema==3.0.0a3
+jsonschema==3.2.0
 
 #require to validate uris
 rfc3987


### PR DESCRIPTION
The `opentargets-validator` package currently has jsonschema pinned to version 3.0.0a3. Now that the latest stable version is 3.2.0, it starts to create some dependency resolution problems for projects which would like to use both the opentargets-validator and the latest jsonschema.

NB: I didn't verify that this change won't break something inside the validator. However, we're using jsonschema 3.2.0 to validate the evidence strings internally, and it seems to be working fine